### PR TITLE
fusefilter: correct comment typo

### DIFF
--- a/include/fusefilter.h
+++ b/include/fusefilter.h
@@ -79,7 +79,7 @@ typedef struct fuse8_s {
   uint64_t seed;
   uint64_t segmentLength; // = slotCount  / FUSE_SLOTS
   uint8_t
-      *fingerprints; // after fuse8_allocate, will point to 3*blockLength values
+      *fingerprints; // after fuse8_allocate, will point to 3*segmentLength values
 } fuse8_t;
 
 // Report if the key is in the set, with false positive rate.


### PR DESCRIPTION
Hello, thanks for the great work on xor filters - really cool!

I noticed in the source here that this comment refers to `blockLength` but the fuse8 implementation has no block length, I think it means `segmentLength` and the typo comes from fuse8 being based on the xor8 implementation.