### PR TITLE
xorfilter: remove inconsistent assignment of blockLength

### DIFF
--- a/include/xorfilter.h
+++ b/include/xorfilter.h
@@ -124,7 +124,6 @@ static inline bool xor8_allocate(uint32_t size, xor8_t *filter) {
 // caller is responsible to call xor8_free(filter)
 static inline bool xor16_allocate(uint32_t size, xor16_t *filter) {
   size_t capacity = 32 + 1.23 * size;
-  filter->blockLength = capacity / 3;
   capacity = capacity / 3 * 3;
   filter->fingerprints = (uint16_t *)malloc(capacity * sizeof(uint16_t));
   if (filter->fingerprints != NULL) {


### PR DESCRIPTION
The assignment of `filter->blockLength` in `xor16_allocate` was performed
twice (line 131), needlessly so far as I can tell, and in direct contradiction to how
`xor8_allocate` and `fuse8_allocate` handle assignment of the same field.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>