### PR TITLE
tests: fuse8: add test for small ~10k keys input

### DIFF
--- a/tests/unit.c
+++ b/tests/unit.c
@@ -151,7 +151,7 @@ bool testbufferedxor16() {
 }
 
 bool testfuse8() {
-  printf("testing fuse8\n");
+  printf("testing fuse8 with 1m keys\n");
 
   fuse8_t filter;
   size_t size = 1000000;
@@ -187,8 +187,46 @@ bool testfuse8() {
   return true;
 }
 
+bool testfuse8_small() {
+  printf("testing fuse8 with 10k keys\n");
+
+  fuse8_t filter;
+  size_t size = 10000;
+  fuse8_allocate(size, &filter);
+  // we need some set of values
+  uint64_t *big_set = (uint64_t *)malloc(sizeof(uint64_t) * size);
+  for (size_t i = 0; i < size; i++) {
+    big_set[i] = i; // we use contiguous values
+  }
+  // we construct the filter
+  fuse8_populate(big_set, size, &filter);
+  for (size_t i = 0; i < size; i++) {
+    if (!fuse8_contain(big_set[i], &filter)) {
+      printf("bug!\n");
+      return false;
+    }
+  }
+
+  size_t random_matches = 0;
+  size_t trials = 10000000; //(uint64_t)rand() << 32 + rand()
+  for (size_t i = 0; i < trials; i++) {
+    uint64_t random_key = ((uint64_t)rand() << 32) + rand();
+    if (fuse8_contain(random_key, &filter)) {
+      if (random_key >= size) {
+        random_matches++;
+      }
+    }
+  }
+  printf("fpp %3.10f (estimated) \n", random_matches * 1.0 / trials);
+  printf("bits per entry %3.1f\n", fuse8_size_in_bytes(&filter) * 8.0 / size);
+  fuse8_free(&filter);
+  free(big_set);
+  return true;
+}
+
 int main() {
   testfuse8();
+  testfuse8_small();
   testbufferedxor8();
   testbufferedxor16();
   testxor8();


### PR DESCRIPTION
This test case is currently failing. I noticed when implementing the fuse8 filter
in Zig that, currently, the implementation here fails to populate if the number of
keys is below 125k:

```
testing fuse8 with 10k keys
Too many iterations. Are all your keys unique?bug!
```

I'm not sure why this is, and would love tips / help debugging this. cc @jbapple