### PR TITLE
binary fuse filter: allow size=0,size=1,size=2 and add tests

### DIFF
--- a/include/binaryfusefilter.h
+++ b/include/binaryfusefilter.h
@@ -144,15 +144,14 @@ static inline double binary_fuse_calculate_size_factor(uint32_t arity,
 // size should be at least 2.
 static inline bool binary_fuse8_allocate(uint32_t size,
                                          binary_fuse8_t *filter) {
-  if(size <= 1) { return false; }
   uint32_t arity = 3;
-  filter->SegmentLength = binary_fuse_calculate_segment_length(arity, size);
+  filter->SegmentLength = size == 0 ? 4 : binary_fuse_calculate_segment_length(arity, size);
   if (filter->SegmentLength > 262144) {
     filter->SegmentLength = 262144;
   }
   filter->SegmentLengthMask = filter->SegmentLength - 1;
   double sizeFactor = binary_fuse_calculate_size_factor(arity, size);
-  uint32_t capacity = (uint32_t)(round((double)size * sizeFactor));
+  uint32_t capacity = size <= 1 ? 0 : (uint32_t)(round((double)size * sizeFactor));
   uint32_t initSegmentCount =
       (capacity + filter->SegmentLength - 1) / filter->SegmentLength -
       (arity - 1);
@@ -410,14 +409,13 @@ static inline bool binary_fuse16_contain(uint64_t key,
 // size should be at least 2.
 static inline bool binary_fuse16_allocate(uint32_t size,
                                          binary_fuse16_t *filter) {
-  if(size <= 1) { return false; }
   uint32_t arity = 3;
-  filter->SegmentLength = binary_fuse_calculate_segment_length(arity, size);
+  filter->SegmentLength = size == 0 ? 4 : binary_fuse_calculate_segment_length(arity, size);
   if (filter->SegmentLength > 262144) {
     filter->SegmentLength = 262144;
   }
   filter->SegmentLengthMask = filter->SegmentLength - 1;
-  double sizeFactor = binary_fuse_calculate_size_factor(arity, size);
+  double sizeFactor = size <= 1 ? 0 : binary_fuse_calculate_size_factor(arity, size);
   uint32_t capacity = (uint32_t)(round((double)size * sizeFactor));
   uint32_t initSegmentCount =
       (capacity + filter->SegmentLength - 1) / filter->SegmentLength -

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -260,4 +260,12 @@ int main() {
     printf("\n");
     printf("======\n");
   }
+
+  // test small edge-case binary fuse input sizes
+  testbinaryfuse8(0);
+  testbinaryfuse8(1);
+  testbinaryfuse8(2);
+  testbinaryfuse16(0);
+  testbinaryfuse16(1);
+  testbinaryfuse16(2);
 }


### PR DESCRIPTION
In dabe36530e3598d648d67012c9a6362b698f5598 checks were added to prevent
creation of filters with `size <= 1`, and while these incredibly small
sizes are not particularly useful in a binary fuse filter, keeping the
property that all sizes `[0..N]` are allowed is nice due to the fact
that, if the restriction is in place, you must:

* Verify your set length is >= 1.
* If it isn't, use a separate code path to lookup and encode your 0, 1, or 2 keys
  outside the binary fuse filter. And also handle encoding that to a file if you
  e.g. intend to serialize the filter to disk.

With this change, input sizes 0,1,2 are allowed and consume no more
memory than size=3 (there is no overflow condition in calculating the
array length.)

Also added a few tests for these three edge cases.

Ref #26 

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>