### PR TITLE
binary_fuse8_max function rename

### DIFF
--- a/include/binaryfusefilter.h
+++ b/include/binaryfusefilter.h
@@ -121,7 +121,7 @@ static inline uint32_t binary_fuse_calculate_segment_length(uint32_t arity,
   }
 }
 
-double binary_fuse8_max(double a, double b) {
+double binary_fuse_max(double a, double b) {
   if (a < b) {
     return b;
   }
@@ -131,9 +131,9 @@ double binary_fuse8_max(double a, double b) {
 static inline double binary_fuse_calculate_size_factor(uint32_t arity,
                                                         uint32_t size) {
   if (arity == 3) {
-    return binary_fuse8_max(1.125, 0.875 + 0.25 * log(1000000.0) / log((double)size));
+    return binary_fuse_max(1.125, 0.875 + 0.25 * log(1000000.0) / log((double)size));
   } else if (arity == 4) {
-    return binary_fuse8_max(1.075, 0.77 + 0.305 * log(600000.0) / log((double)size));
+    return binary_fuse_max(1.075, 0.77 + 0.305 * log(600000.0) / log((double)size));
   } else {
     return 2.0;
   }


### PR DESCRIPTION
`binary_fuse8_max` is utilized by `binary_fuse_calculate_size_factor` which is present in both binary fuse 8 and 16 structs, minor naming but would be helpful to denote that this isn't fuse8 exclusive.