### PR TITLE
Add some sanity checks on allocating functions

### DIFF
--- a/include/binaryfusefilter.h
+++ b/include/binaryfusefilter.h
@@ -211,7 +211,7 @@ static inline bool binary_fuse8_allocate(uint32_t size,
     filter->SegmentLength = 262144;
   }
   filter->SegmentLengthMask = filter->SegmentLength - 1;
-  double sizeFactor = binary_fuse_calculate_size_factor(arity, size);
+  double sizeFactor = size <= 1 ? 0 : binary_fuse_calculate_size_factor(arity, size);
   uint32_t capacity = size <= 1 ? 0 : (uint32_t)(round((double)size * sizeFactor));
   uint32_t initSegmentCount =
       (capacity + filter->SegmentLength - 1) / filter->SegmentLength -
@@ -499,7 +499,7 @@ static inline bool binary_fuse16_allocate(uint32_t size,
   }
   filter->SegmentLengthMask = filter->SegmentLength - 1;
   double sizeFactor = size <= 1 ? 0 : binary_fuse_calculate_size_factor(arity, size);
-  uint32_t capacity = (uint32_t)(round((double)size * sizeFactor));
+  uint32_t capacity = size <= 1 ? 0 : (uint32_t)(round((double)size * sizeFactor));
   uint32_t initSegmentCount =
       (capacity + filter->SegmentLength - 1) / filter->SegmentLength -
       (arity - 1);


### PR DESCRIPTION
Try to have the same checks on both `binary_fuse8_allocate()` and on `binary_fuse16_allocate`: `size` parameter should be 2, at least