### PR TITLE
Uninitialized Fingerprints in binary_fuse filters. 

### DIFF
--- a/include/binaryfusefilter.h
+++ b/include/binaryfusefilter.h
@@ -243,7 +243,8 @@ static inline bool binary_fuse8_allocate(uint32_t size,
   filter->ArrayLength =
       (filter->SegmentCount + arity - 1) * filter->SegmentLength;
   filter->SegmentCountLength = filter->SegmentCount * filter->SegmentLength;
-  filter->Fingerprints = (uint8_t*)malloc(filter->ArrayLength);
+  filter->Fingerprints =
+      (uint8_t *)calloc(filter->ArrayLength, sizeof(uint8_t));
   return filter->Fingerprints != NULL;
 }
 
@@ -530,7 +531,8 @@ static inline bool binary_fuse16_allocate(uint32_t size,
   filter->ArrayLength =
       (filter->SegmentCount + arity - 1) * filter->SegmentLength;
   filter->SegmentCountLength = filter->SegmentCount * filter->SegmentLength;
-  filter->Fingerprints = (uint16_t*)malloc(filter->ArrayLength * sizeof(uint16_t));
+  filter->Fingerprints =
+      (uint16_t *)calloc(filter->ArrayLength, sizeof(uint16_t));
   return filter->Fingerprints != NULL;
 }
 


### PR DESCRIPTION
In both versions of `binary_fuse*_allocate`, `filter->Fingerprints` is allocated, but uninitialized. During `binary_fuse*_populate`, this uninitialized valued is used when setting the filter:

```c
filter->Fingerprints[h012[found]] = xor2 ^
                                        filter->Fingerprints[h012[found + 1]] ^
                                        filter->Fingerprints[h012[found + 2]];
```

This change 0 initializes `filter->Fingerprints`. I believe this is correct, as in "Binary Fuse Filters: Fast and Smaller Than Xor Filters," `H` is defined as a 0 initialized array in Algorithm 1. 